### PR TITLE
fix: remove last csv line to match the number of frames extacted

### DIFF
--- a/src/lib/etl_data/load.py
+++ b/src/lib/etl_data/load.py
@@ -15,5 +15,6 @@ def load_physiological_records(records, records_name, output_records_dir):
         output_records_dir, records_name, "physiological_record.csv"
     )
     df = pd.DataFrame(records)
+    df = df.iloc[:-1]
     df.to_csv(output_records_path, index=False)
     print(records_name, os.path.basename(output_records_dir))


### PR DESCRIPTION
Il y avait une différence entre le nombre de frames extraites (900) et entre le nombre de valeurs PPG extraites dans le .csv (901).
J'ai donc supprimé la dernière ligne afin de correspondre le nombre d'images avec le nombre de labels.